### PR TITLE
FIX: ttyRS485 and ttyConBridge on kernels > 4.20

### DIFF
--- a/50-revpi.rules
+++ b/50-revpi.rules
@@ -10,8 +10,8 @@ ACTION=="add", DEVPATH=="*/spi0.1/net/*eth*", NAME="piright", ENV{SYSTEMD_WANTS}
 GOTO="revpi_end"
 
 LABEL="revpi_connect"
-ACTION=="add", DEVPATH=="*/usb1/1-1/1-1.5/1-1.5.2/*", SYMLINK+="ttyRS485"
-ACTION=="add", DEVPATH=="*/usb1/1-1/1-1.5/1-1.5.3/*", SYMLINK+="ttyConBridge"
+ACTION=="add", DEVPATH=="*/usb1/1-1/1-1.5/1-1.5.2/*", SUBSYSTEM=="tty", SYMLINK+="ttyRS485"
+ACTION=="add", DEVPATH=="*/usb1/1-1/1-1.5/1-1.5.3/*", SUBSYSTEM=="tty", SYMLINK+="ttyConBridge"
 ACTION=="add", DEVPATH=="*/spi0.1/net/*eth*", NAME="pileft"
 GOTO="revpi_end"
 


### PR DESCRIPTION
The ftdi_sio driver was extended to implemnt a gpiocontroller. This
leads to the situation, that the symlink now points to gpiochip3 and not
to ttyUSB0. The same goes for the ttyConBridge symlink.

ba93cc7da896 (USB: serial: ftdi_sio: implement GPIO support for FT-X devices)

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>