### PR TITLE
install revpi_buster_fix_pictory.sh to /usr/sbin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+revpi-tools (1.0.15-2) stable; urgency=medium
+
+  * install revpi_buster_fix_pictory.sh to /usr/sbin
+
+ -- Frank Pavlic <f.pavlic@kunbus.com>  Wed, 30 Jun 2021 07:27:15 +0200
+
 revpi-tools (1.0.15-1) stable; urgency=medium
 
   [ Philipp Rosenberger ]

--- a/debian/revpi-tools.install
+++ b/debian/revpi-tools.install
@@ -12,4 +12,5 @@ revpi-connect-watchdog.sh	/home/pi/connect
 revpi-sos			/usr/bin
 revpi.py			/usr/share/sosreport/sos/plugins
 revpi_buster_fixup_pkgs.py	/usr/sbin
+revpi_buster_fix_pictory.sh	/usr/sbin
 revpi_buster_upgrade_fix_nodered.sh	/usr/sbin


### PR DESCRIPTION
revpi_buster_fix_pictory.sh added to revpi-tools.install
otherwise the debian package won't contain the script.
Install the script to /usr/sbin once the package will be installed.

Signed-off-by: Frank Pavlic <f.pavlic@kunbus.com>