### PR TITLE
Make the device matching in udev rules more robust REVPI-1719

### DIFF
--- a/50-revpi.rules
+++ b/50-revpi.rules
@@ -1,7 +1,8 @@
-PROGRAM="/bin/grep -F 'kunbus,revpi-core'    /sys/firmware/devicetree/base/compatible", GOTO="revpi_core"
-PROGRAM="/bin/grep -F 'kunbus,revpi-connect' /sys/firmware/devicetree/base/compatible", GOTO="revpi_connect"
-PROGRAM="/bin/grep -F 'kunbus,revpi-compact' /sys/firmware/devicetree/base/compatible", GOTO="revpi_compact"
-PROGRAM="/bin/grep -F 'kunbus,revpi-flat'    /sys/firmware/devicetree/base/compatible", GOTO="revpi_flat"
+PROGRAM="/bin/grep -Fz -m 1 'kunbus,revpi-' /sys/firmware/devicetree/base/compatible"
+RESULT=="kunbus,revpi-core", GOTO="revpi_core"
+RESULT=="kunbus,revpi-connect", GOTO="revpi_connect"
+RESULT=="kunbus,revpi-compact", GOTO="revpi_compact"
+RESULT=="kunbus,revpi-flat", GOTO="revpi_flat"
 GOTO="revpi_end"
 
 LABEL="revpi_core"


### PR DESCRIPTION
The current matching just checks if the compatible string is a
substring. This might lead to preoblems later if new revisions of a
device will be released. For example a RevPi Connect 4 might have the
follwing compatible "kunbus,revpi-connect4". The rule fot the current
RevPi Connect would match the old and the new RevPi Connect.

Change the matcher to match also the string end.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>