### PR TITLE
Fix missing systemd tag

### DIFF
--- a/50-revpi.rules
+++ b/50-revpi.rules
@@ -10,8 +10,8 @@ RESULT=="kunbus,revpi-flat", GOTO="revpi_flat"
 GOTO="revpi_end"
 
 LABEL="revpi_core"
-ACTION=="add", DEVPATH=="*/spi0.0/net/*eth*", NAME="pileft", ENV{SYSTEMD_WANTS}="pileft-quirks.service"
-ACTION=="add", DEVPATH=="*/spi0.1/net/*eth*", NAME="piright", ENV{SYSTEMD_WANTS}="piright-quirks.service"
+ACTION=="add", DEVPATH=="*/spi0.0/net/*eth*", NAME="pileft", TAG+="systemd", ENV{SYSTEMD_WANTS}="pileft-quirks.service"
+ACTION=="add", DEVPATH=="*/spi0.1/net/*eth*", NAME="piright", TAG+="systemd", ENV{SYSTEMD_WANTS}="piright-quirks.service"
 GOTO="revpi_end"
 
 LABEL="revpi_connect"


### PR DESCRIPTION
Without TAG+="systemd" systemd does not create a corresponding .device file for the device in the udev rule. Therefore the service which is specified in ENV{SYSTEMD_WANTS} won't be executed (ENV{SYSTEMD_WANTS} adds a dependency to the service in the device file). For more details see systemd.device(5).