### PR TITLE
Change deb architecture to any

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Maintainer: KUNBUS GmbH <support@kunbus.com>
 Homepage: https://revolutionpi.com
 
 Package: revpi-tools
-Architecture: armhf
+Architecture: any
 Depends: sosreport, python3-ftdi1, iproute2, ${misc:Depends}
 Description: Revolution Pi tools
  Assorted tools and support files for Revolution Pi products:


### PR DESCRIPTION
With the current architecture pinned to armhf it is not possible to build packages for arm64. Therefore we need to switch to any. The only tool which is shipped as binary is patch-eeprom and has successfully been tested on arm64.

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>