### PR TITLE
Add dependency to python3-revpi-device-info

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://revolutionpi.com
 
 Package: revpi-tools
 Architecture: any
-Depends: sosreport, python3-ftdi1, iproute2, ${misc:Depends}
+Depends: sosreport, python3-ftdi1, iproute2, python3-revpi-device-info, ${misc:Depends}
 Description: Revolution Pi tools
  Assorted tools and support files for Revolution Pi products:
  .


### PR DESCRIPTION
In the revpi plugin of sosreport, the command "revpi-device-info" is used to collect the device information, e.g. procfs node of HAT EEPROM. The command is contained in package python3-revpi-device-info, so it is needed to add the dependency.

Signed-off-by: Zhi Han <z.han@kunbus.com>