### PR TITLE
Fix broken function names to repair X login [REVPI-2868]

### DIFF
--- a/revpi-factory-reset/revpi-factory-reset
+++ b/revpi-factory-reset/revpi-factory-reset
@@ -11,7 +11,7 @@
 . /usr/share/revpi/revpi-functions
 
 full_devicetype_list="compact|connect|core|flat|connect-se"	# all suported devices
-if has-hat-eeprom; then
+if has_hat_eeprom; then
 	# The device is equipped with HAT EEPROM
 	with_hat_eeprom=true
 
@@ -39,7 +39,7 @@ else
 	fi
 
 	if [ "$ovl" = "core" ]; then
-		if cm1-detection; then
+		if cm1_detection; then
 			echo "Compute Module 1 has been detected, core-cm1-overlay will be used"
 			echo "automatically."
 			ovl="core-cm1"

--- a/revpi-factory-reset/revpi-factory-reset.sh
+++ b/revpi-factory-reset/revpi-factory-reset.sh
@@ -17,7 +17,7 @@ export NEWT_COLORS='root=,black entry=white,black'
 
 while [ ! -r /home/pi/.revpi-factory-reset ] ; do
 	clear
-	if has-hat-eeprom; then
+	if has_hat_eeprom; then
 		# The device is equipped with HAT EEPROM
 		whiptail --nocancel --title "INFO" --msgbox "The device configuration was detected automatically. Manual configuration is therefore not necessary." 0 0
 
@@ -25,7 +25,7 @@ while [ ! -r /home/pi/.revpi-factory-reset ] ; do
 		return
 	fi
 	msg="Please select the Product Type:"
-	if cm1-detection; then
+	if cm1_detection; then
 		ovl=$(whiptail --notags --title "PRODUCT TYPE" --menu "$msg" 0 0 0 \
 			core "RevPi Core (autodetected)" \
 			3>&1 1>&2 2>&3)

--- a/revpi-factory-reset/revpi-functions
+++ b/revpi-factory-reset/revpi-functions
@@ -5,14 +5,14 @@
 # Copyright: 2022 KUNBUS GmbH
 #
 
-cm1-detection() {
+cm1_detection() {
     grep -m 1 "model name" /proc/cpuinfo | grep -q v6l
     return $?
 }
 
 # Check existance of HAT EEPROM according to document:
 # https://github.com/RevolutionPi/revpi-hat-eeprom/blob/master/docs/RevPi-HAT-EEPROM-Format.md#custom-atoms
-has-hat-eeprom() {
+has_hat_eeprom() {
 	if [ -e /proc/device-tree/hat/custom_1 ]; then
 		return 0;
 	fi


### PR DESCRIPTION
Having dashes in the function names in revpi-functions breaks Xsession and therefore it is not possible to login via graphical target. The login silently fails with looping back to login after the password was entered successful.

From ~/.xsession-errors:

"/etc/X11/Xsession: 8: /usr/share/revpi/revpi-functions: Syntax error: Bad function name"

Function names in bash should not contain - (dash). From bash manual:

"A word consisting solely of letters, numbers, and underscores, and beginning with a letter or underscore. Names are used as shell variable and function names. Also referred to as an identifier."

Fix this by replacing the dashed with underscores.

Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>