### PR TITLE
Add Connect 4 to udev rules.

### DIFF
--- a/udev/50-revpi.rules
+++ b/udev/50-revpi.rules
@@ -5,6 +5,7 @@ RESULT=="kunbus,revpi-core-s-2022", GOTO="revpi_core"
 RESULT=="kunbus,revpi-core-se-2022", GOTO="revpi_end"
 RESULT=="kunbus,revpi-connect", GOTO="revpi_connect"
 RESULT=="kunbus,revpi-connect-se", GOTO="revpi_connect"
+RESULT=="kunbus,revpi-connect4", GOTO="revpi_connect4"
 RESULT=="kunbus,revpi-compact", GOTO="revpi_compact"
 RESULT=="kunbus,revpi-flat", GOTO="revpi_flat"
 GOTO="revpi_end"
@@ -19,6 +20,10 @@ ACTION=="add", DEVPATH=="*/usb1/1-1/1-1.5/1-1.5.2/*", SUBSYSTEM=="tty", SYMLINK+
 ACTION=="add", DEVPATH=="*/usb1/1-1/1-1.5/1-1.5.3/*", SUBSYSTEM=="tty", SYMLINK+="ttyConBridge"
 # This rule doesn't match on the RevPi Connect SE as it has no ethernet on the pibridge.
 ACTION=="add", DEVPATH=="*/spi0.1/net/*eth*", NAME="pileft"
+GOTO="revpi_end"
+
+LABEL="revpi_connect4"
+ACTION=="add", DEVPATH=="*/ttyAMA2", SYMLINK+="ttyRS485"
 GOTO="revpi_end"
 
 LABEL="revpi_compact"


### PR DESCRIPTION
The device RevPi Connect 4 is added to the udev rules. It adds the front RS485 as /dev/ttyRS485.