### PR TITLE
Stop installation of files in user directory [REVPI-3094]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(revpi-tools)
+project(revpi-tools LANGUAGES C)
 
 include(GNUInstallDirs)
 

--- a/examples-watchdog/CMakeLists.txt
+++ b/examples-watchdog/CMakeLists.txt
@@ -1,11 +1,12 @@
 add_executable(patch_eeprom patch_eeprom.c)
 
 target_link_libraries(patch_eeprom ftdi1)
+include(GNUInstallDirs)
 
 install(TARGETS patch_eeprom
   DESTINATION /home/pi/connect/
 )
 
 install(FILES README patch_eeprom.c enable_relay_watchdog.py disable_relay_watchdog.py revpi-connect-watchdog.sh
-  DESTINATION /home/pi/connect/
+  DESTINATION ${CMAKE_INSTALL_DOCDIR}
 )

--- a/examples-watchdog/CMakeLists.txt
+++ b/examples-watchdog/CMakeLists.txt
@@ -4,7 +4,7 @@ target_link_libraries(patch_eeprom ftdi1)
 include(GNUInstallDirs)
 
 install(TARGETS patch_eeprom
-  DESTINATION /home/pi/connect/
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/revpi-tools/
 )
 
 install(FILES README patch_eeprom.c enable_relay_watchdog.py disable_relay_watchdog.py revpi-connect-watchdog.sh

--- a/examples-watchdog/README
+++ b/examples-watchdog/README
@@ -3,7 +3,7 @@ How to use the watchdog on the RevPi Connect to also powercycle the relay
 The FTDI EEPROM is patched as follows during factory end-of-line test
 (and a reboot is performed afterwards for the change to take effect): 
 devnum=$(cat /sys/bus/usb/devices/1-1.5.2/devnum)
-sudo /home/pi/connect/patch_eeprom d:1/$devnum 0x14=0xaa 0x15=0x00
+sudo /usr/lib/revpi-tools/patch_eeprom d:1/$devnum 0x14=0xaa 0x15=0x00
 
 
 Now enable or disable the relay on a watchdog reset like this:

--- a/examples-watchdog/README
+++ b/examples-watchdog/README
@@ -7,8 +7,8 @@ sudo /home/pi/connect/patch_eeprom d:1/$devnum 0x14=0xaa 0x15=0x00
 
 
 Now enable or disable the relay on a watchdog reset like this:
-sudo /home/pi/connect/enable_relay_watchdog.py
-sudo /home/pi/connect/disable_relay_watchdog.py
+sudo /usr/share/doc/revpi-tools/enable_relay_watchdog.py
+sudo /usr/share/doc/revpi-tools/disable_relay_watchdog.py
 
 If you want the relay to be switched you have to enable it each time the RevPi 
 is booted. Invoke the Python script enable_relay_watchdog.py from /etc/rc.local


### PR DESCRIPTION
Project files must not be installed in /home directory. Instead documentation and binaries have been placed into either
`/usr/share/doc` or `/usr/lib`. The resulting installation paths look like this now

```
$ sudo make install
[100%] Built target patch_eeprom
[100%] Built target lan9514.bin
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/etc/avahi/services/revpi-ssh.service
-- Installing: /usr/lib/revpi-tools/patch_eeprom
-- Installing: /usr/share/doc/revpi-tools/README
-- Installing: /usr/share/doc/revpi-tools/patch_eeprom.c
-- Installing: /usr/share/doc/revpi-tools/enable_relay_watchdog.py
-- Installing: /usr/share/doc/revpi-tools/disable_relay_watchdog.py
-- Installing: /usr/share/doc/revpi-tools/revpi-connect-watchdog.sh
-- Installing: /lib/systemd/system/firstboot.service
-- Installing: /usr/local/share/revpi/firstboot/resize-fs.sh
-- Installing: /usr/local/sbin/revpi_buster_upgrade_fix_nodered.sh
-- Installing: /usr/local/sbin/revpi_buster_fix_pictory.sh
-- Installing: /usr/local/sbin/revpi_buster_fixup_pkgs.py
-- Installing: /usr/local/sbin/revpi-config
-- Installing: /usr/local/share/man/man1/revpi-config.1
-- Installing: /usr/local/share/revpi/revpi-functions
-- Installing: /usr/local/sbin/revpi-factory-reset
-- Installing: /usr/local/etc/profile.d/revpi-factory-reset.sh
-- Installing: /usr/local/share/man/man8/revpi-factory-reset.8
-- Installing: /usr/local/bin/revpi-sos
-- Installing: /usr/local/share/sosreport/sos/plugins/revpi.py
-- Installing: /usr/local/share/man/man1/revpi-sos.1
-- Installing: /lib/systemd/system/pileft-quirks.service
-- Installing: /lib/systemd/system/piright-quirks.service
-- Installing: /lib/systemd/system/hdmi-disable.service
-- Installing: /usr/local/sbin/pibridge-shutdown
-- Installing: /usr/local/share/man/man8/pibridge-shutdown.8
-- Installing: /usr/local/sbin/ks8851-set-mac
-- Installing: /usr/local/sbin/lan95xx-set-mac
-- Installing: /usr/local/share/man/man8/ks8851-set-mac.8
-- Installing: /usr/local/share/revpi/lan9514.bin
-- Installing: /lib/udev/rules.d/50-revpi.rules
```