### PR TITLE
Remove dependency to sosreport [REVPI-1692]

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Depends:
   ${misc:Depends},
   ${python3:Depends},
   ${shlibs:Depends}
-Suggests: python3-revpi-device-info
+Suggests: revpi-sos-report
 Breaks: piserial (<< 3.0.0)
 Description: Revolution Pi tools
  Assorted tools and support files for Revolution Pi products:

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,6 @@ Depends:
   parted,
   piserial (>= 3.0.0),
   python3-ftdi1,
-  sosreport,
   sudo,
   ${misc:Depends},
   ${python3:Depends},


### PR DESCRIPTION
Beginning with Bullseye the revpi sos report plugins will be moved into a separate package. The package repository is located here:

https://github.com/RevolutionPi/revpi-sos-report

Therefore we need to remove the unnecessary to sos-report in this package.