### PR TITLE
fix: Install revpi-config to /usr/bin

### DIFF
--- a/revpi-config/CMakeLists.txt
+++ b/revpi-config/CMakeLists.txt
@@ -1,5 +1,5 @@
 install(FILES revpi-config
-  DESTINATION ${CMAKE_INSTALL_SBINDIR}/
+  DESTINATION ${CMAKE_INSTALL_BINDIR}/
 )
 
 install(FILES revpi-config.1


### PR DESCRIPTION
In the commit 23b5ee5, the revpi-config script was moved from revpi-webstatus to revpi-tools. It enables configurations on the Revolution Pi, which can be done via the CLI. The installation path has been changed to /usr/sbin, which can cause problems with other packages or customer applications. In addition, this command is based on raspi-config, which is also installed in /usr/bin. This commit corrects the installation path.