### PR TITLE
Allow Connect 4 WLAN and BT configuration with revpi-config

### DIFF
--- a/revpi-config/revpi-config
+++ b/revpi-config/revpi-config
@@ -49,8 +49,8 @@ is_cm3() {
 }
 
 is_revpi_connect() {
-	/bin/grep -F -q 'kunbus,revpi-connect' /sys/firmware/devicetree/base/compatible &&
-		! /bin/grep -F -q 'kunbus,revpi-connect4' /sys/firmware/devicetree/base/compatible
+	/bin/grep -F -q 'kunbus,revpi-connect' /proc/device-tree/compatible &&
+		! /bin/grep -F -q 'kunbus,revpi-connect4' /proc/device-tree/compatible
 }
 
 # do_governor <verb> <governor>

--- a/revpi-config/revpi-config
+++ b/revpi-config/revpi-config
@@ -49,7 +49,8 @@ is_cm3() {
 }
 
 is_revpi_connect() {
-	/bin/grep -F -q 'kunbus,revpi-connect' /sys/firmware/devicetree/base/compatible
+	/bin/grep -F -q 'kunbus,revpi-connect' /sys/firmware/devicetree/base/compatible &&
+		! /bin/grep -F -q 'kunbus,revpi-connect4' /sys/firmware/devicetree/base/compatible
 }
 
 # do_governor <verb> <governor>

--- a/revpi-config/revpi-config
+++ b/revpi-config/revpi-config
@@ -223,17 +223,19 @@ do_service() {
 # do_wireless <verb> <type> (where type is "bluetooth" or "ieee80211")
 do_wireless() {
 	shopt -s nullglob
-	if grep -q "revpi-flat" "/proc/device-tree/compatible"; then
+	if grep -q -E "(revpi-flat|revpi-connect4)" "/proc/device-tree/compatible"; then
 		if [ "$2" = "ieee80211" ] ; then
 			#built-in devices are recognizable by having a devicetree node
-			IDX=(/sys/class/"$2"/*/device/of_node)
-			if [ "$IDX" ] ; then
-				IDX="${IDX%%/device/of_node}"	# strip trailing /device/of_node
+			IDX=(/sys/class/"$2"/*)
+			if grep -q -F 'DRIVER=brcmfmac' "$IDX"/device/uevent; then
 				IDX=("$IDX"/rfkill*)		# search for rfkill directory
 				IDX="${IDX##*/rfkill}"		# strip everything except index
 			fi
 		else
-			[ ! -c /dev/ttyUSB0 ] && return 0
+			if grep -q "revpi-flat" "/proc/device-tree/compatible"; then
+				[ ! -c /dev/ttyUSB0 ] && return 0
+			fi
+
 			IDX=(/sys/class/bluetooth/hci0)
 			[ -L "$IDX" ] || hciattach /dev/ttyUSB0 any
 			# check if device available


### PR DESCRIPTION
Without patches:
![Screenshot from 2023-04-15 15-15-15](https://user-images.githubusercontent.com/9132055/232226127-9c640890-0c7a-4b58-bb9c-2d09c72b3a75.png)

With patches:
![Screenshot from 2023-04-15 15-13-36](https://user-images.githubusercontent.com/9132055/232226132-78660deb-9c50-40d0-aa46-443102320ff7.png)

Patches have been tested on RevPi Flat and everything works as expected. Someone please check if the CAN module is configurable on a RevPi Connect < 4
