### PR TITLE
fix: use PROGRAM instead of FILE in CMakeLists.txt for scripts

### DIFF
--- a/firstboot/CMakeLists.txt
+++ b/firstboot/CMakeLists.txt
@@ -2,6 +2,6 @@ install(FILES firstboot.service
   DESTINATION /lib/systemd/system/
 )
 
-install(FILES resize-fs.sh
+install(PROGRAMS resize-fs.sh
   DESTINATION ${CMAKE_INSTALL_DATADIR}/revpi/firstboot/
 )

--- a/revpi-config/CMakeLists.txt
+++ b/revpi-config/CMakeLists.txt
@@ -1,4 +1,4 @@
-install(FILES revpi-config
+install(PROGRAMS revpi-config
   DESTINATION ${CMAKE_INSTALL_BINDIR}/
 )
 


### PR DESCRIPTION
Fixes the bug that scripts were not executable when copied via CMake.

This change was tested for Bullseye in Debianization and the scripts are executable again.