### PR TITLE
udev: Use soc address for RS485 uart alias

### DIFF
--- a/udev/50-revpi.rules
+++ b/udev/50-revpi.rules
@@ -23,7 +23,7 @@ ACTION=="add", DEVPATH=="*/spi0.1/net/*eth*", NAME="pileft"
 GOTO="revpi_end"
 
 LABEL="revpi_connect4"
-ACTION=="add", DEVPATH=="*/ttyAMA2", SYMLINK+="ttyRS485"
+ACTION=="add", DEVPATH=="/devices/platform/soc/fe201a00.serial/*", SYMLINK+="ttyRS485"
 GOTO="revpi_end"
 
 LABEL="revpi_compact"


### PR DESCRIPTION
The enumeration of /dev/ttyAMA* is likely to change, if we switch to serdev for our piBridge interface. This would render this rule useless. Fix this by using the soc address of the uart instead.