### PR TITLE
Use pkg-config to get the install paths for systemd service and udev files

### DIFF
--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -1,3 +1,7 @@
+include(FindPkgConfig)
+pkg_check_modules(SYSTEMD REQUIRED "systemd")
+pkg_get_variable(SYSTEMD_SYSTEMUNITDIR "systemd" "systemdsystemunitdir")
+
 install(FILES pileft-quirks.service piright-quirks.service hdmi-disable.service
-  DESTINATION /lib/systemd/system
+  DESTINATION ${SYSTEMD_SYSTEMUNITDIR}
 )

--- a/udev/CMakeLists.txt
+++ b/udev/CMakeLists.txt
@@ -1,7 +1,11 @@
+include(FindPkgConfig)
+pkg_check_modules(UDEV REQUIRED "udev")
+pkg_get_variable(UDEV_UDEVDIR "udev" "udevdir")
+
 install(FILES 50-revpi.rules
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d
+  DESTINATION ${UDEV_UDEVDIR}/rules.d
 )
 
 install(PROGRAMS revpi_mac
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev
+  DESTINATION ${UDEV_UDEVDIR}
 )


### PR DESCRIPTION
The resulting tree when installing:

```
[tboehler@elitebook build]$ tree pkg
pkg
├── lib
│   ├── systemd
│   │   └── system
│   │       ├── firstboot.service
│   │       ├── hdmi-disable.service
│   │       ├── pileft-quirks.service
│   │       └── piright-quirks.service
│   └── udev
│       ├── revpi_mac
│       └── rules.d
│           └── 50-revpi.rules
└── usr
    └── local
        ├── bin
        │   └── revpi-config
        ├── etc
        │   ├── avahi
        │   │   └── services
        │   │       └── revpi-ssh.service
        │   └── profile.d
        │       └── revpi-factory-reset.sh
        ├── lib
        │   └── revpi-tools
        │       └── patch_eeprom
        ├── sbin
        │   ├── ks8851-set-mac
        │   ├── lan78xx-set-mac
        │   ├── lan95xx-set-mac
        │   ├── pibridge-shutdown
        │   ├── revpi-factory-reset
        │   └── revpi-set-mac
        └── share
            ├── doc
            │   └── revpi-tools
            │       ├── disable_relay_watchdog.py
            │       ├── enable_relay_watchdog.py
            │       ├── patch_eeprom.c
            │       ├── README
            │       └── revpi-connect-watchdog.sh
            ├── man
            │   ├── man1
            │   │   └── revpi-config.1
            │   └── man8
            │       ├── ks8851-set-mac.8
            │       ├── pibridge-shutdown.8
            │       └── revpi-factory-reset.8
            └── revpi
                ├── firstboot
                │   └── resize-fs.sh
                ├── lan7800.bin
                ├── lan9514.bin
                └── revpi-functions

24 directories, 29 files
```