### PR TITLE
fix(udev): Remove systemd tag for hdmi-disable rule

### DIFF
--- a/udev/50-revpi.rules
+++ b/udev/50-revpi.rules
@@ -41,7 +41,7 @@ GOTO="revpi_end"
 LABEL="revpi_flat"
 ACTION=="add", DEVPATH=="*/ttyAMA0", SYMLINK+="ttyRS485-0"
 ACTION=="add", DEVPATH=="*/ttyS0", SYMLINK+="ttyRS485-1"
-ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}="hdmi-disable.service"
+ACTION=="add", ENV{SYSTEMD_WANTS}="hdmi-disable.service"
 GOTO="revpi_end"
 
 LABEL="revpi_end"


### PR DESCRIPTION
The udev rule which triggers the hdmi-disable.service on RevPi Flat matches every device path during ACTION="add". It is also tagged with the "systemd" tag, which will result in lots of unwanted systemd devices files. These device files are for example checked for dependencies on EACH ssh login due to the usage of pam_systemd.so.

Fromn the systemd.device man page:

"
Note that this and the other udev device properties are not taken into account unless the device is tagged with the "systemd" tag in the udev database, because otherwise the device is not exposed as a systemd unit (see above). "

This behaviour is not wanted here and will lead to increased ssh login times on a RevPi Flat.

Fix this by removing the systemd tag.

# Setup with systemd tag (broken)
![user-flat2](https://github.com/RevolutionPi/revpi-tools/assets/9132055/21be54ff-2902-4799-9a94-7f1c35f5cacb)

```
Jun 20 21:31:29 RevPi465 systemd[1]: Starting User Manager for UID 1000...
Jun 20 21:31:29 RevPi465 systemd[1573]: pam_unix(systemd-user:session): session opened for user pi(uid=1000) by (uid=0)
Jun 20 21:31:30 RevPi465 systemd[1]: systemd-hostnamed.service: Succeeded.
Jun 20 21:31:33 RevPi465 systemd[1573]: Queued start job for default target Main User Target.
Jun 20 21:31:33 RevPi465 systemd[1573]: Created slice User Application Slice.
Jun 20 21:31:33 RevPi465 systemd[1573]: Reached target Paths.
Jun 20 21:31:33 RevPi465 systemd[1573]: Reached target Timers.
Jun 20 21:31:33 RevPi465 systemd[1573]: Starting D-Bus User Message Bus Socket.
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on GnuPG network certificate management daemon.
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on GnuPG cryptographic agent and passphrase cache (access for web browsers).
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on GnuPG cryptographic agent and passphrase cache (restricted).
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on GnuPG cryptographic agent (ssh-agent emulation).
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on GnuPG cryptographic agent and passphrase cache.
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on Multimedia System.
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on debconf communication socket.
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on Sound System.
Jun 20 21:31:33 RevPi465 systemd[1573]: Listening on D-Bus User Message Bus Socket.
Jun 20 21:31:33 RevPi465 systemd[1573]: Reached target Sockets.
Jun 20 21:31:33 RevPi465 systemd[1573]: Reached target Basic System.
Jun 20 21:31:33 RevPi465 systemd[1]: Started User Manager for UID 1000.
Jun 20 21:31:33 RevPi465 systemd[1573]: Reached target Main User Target.
Jun 20 21:31:33 RevPi465 systemd[1573]: Startup finished in 4.183s.
```



# Setup without systemd tag (fixed)
![user-flat3](https://github.com/RevolutionPi/revpi-tools/assets/9132055/62daba55-1150-45f5-aaa8-7d8b1dc18a67)

```
Jun 20 22:01:58 RevPi465 sshd[1692]: Accepted password for pi from 2001:9e8:36b:da00:3a53:df9:ea77:8935 port 41892 ssh2
Jun 20 22:01:58 RevPi465 sshd[1692]: pam_unix(sshd:session): session opened for user pi(uid=1000) by (uid=0)
Jun 20 22:01:58 RevPi465 systemd[1]: Created slice User Slice of UID 1000.
Jun 20 22:01:58 RevPi465 systemd[1]: Starting User Runtime Directory /run/user/1000...
Jun 20 22:01:58 RevPi465 systemd-logind[1123]: New session 5 of user pi.
Jun 20 22:01:58 RevPi465 systemd[1]: Finished User Runtime Directory /run/user/1000.
Jun 20 22:01:58 RevPi465 systemd[1]: Starting User Manager for UID 1000...
Jun 20 22:01:58 RevPi465 systemd[1695]: pam_unix(systemd-user:session): session opened for user pi(uid=1000) by (uid=0)
Jun 20 22:01:59 RevPi465 systemd[1695]: Queued start job for default target Main User Target.
Jun 20 22:01:59 RevPi465 systemd[1695]: Created slice User Application Slice.
Jun 20 22:01:59 RevPi465 systemd[1695]: Reached target Paths.
Jun 20 22:01:59 RevPi465 systemd[1695]: Reached target Timers.
Jun 20 22:01:59 RevPi465 systemd[1695]: Starting D-Bus User Message Bus Socket.
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on GnuPG network certificate management daemon.
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on GnuPG cryptographic agent and passphrase cache (access for web browsers).
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on GnuPG cryptographic agent and passphrase cache (restricted).
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on GnuPG cryptographic agent (ssh-agent emulation).
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on GnuPG cryptographic agent and passphrase cache.
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on Multimedia System.
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on debconf communication socket.
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on Sound System.
Jun 20 22:01:59 RevPi465 systemd[1695]: Listening on D-Bus User Message Bus Socket.
Jun 20 22:01:59 RevPi465 systemd[1695]: Reached target Sockets.
Jun 20 22:01:59 RevPi465 systemd[1695]: Reached target Basic System.
Jun 20 22:01:59 RevPi465 systemd[1695]: Reached target Main User Target.
Jun 20 22:01:59 RevPi465 systemd[1695]: Startup finished in 662ms.
```
